### PR TITLE
Using default value when path is not specified

### DIFF
--- a/src/generateSpec.ts
+++ b/src/generateSpec.ts
@@ -11,7 +11,7 @@ import { IRoute } from './index'
 /** Return full Express path of given route. */
 export function getFullExpressPath(route: IRoute): string {
   const { action, controller, options } = route
-  return (options.routePrefix || '') + controller.route + action.route
+  return (options.routePrefix || '') + controller.route + (action.route || '')
 }
 
 /**


### PR DESCRIPTION
```typescript
@JsonController('/api')
class Controller {

   @Get()
   public async find(): Promise<any> {
   }
}
```
If you don't specify the path '/' in the @Get(), it will write  '/apiundefined' in the json file.