### PR TITLE
Handle multiple OpenAPI decorators on a single handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,23 @@ The parameter object consists of any number of properties from the [Operation ob
 
 Alternatively you can call `@OpenAPI` with a function of type `(source: OperationObject, route: IRoute) => OperationObject`, i.e. a function receiving the existing spec as well as the target route, spitting out an updated spec. This function parameter can be used to implement for example your own merging logic or custom decorators.
 
+#### Multiple `@OpenAPI` decorators
+
+A single handler can be decorated with multiple `@OpenAPI`s. Note though that since decorators are applied top-down, any possible duplicate keys are overwritten by subsequent decorators:
+
+```typescript
+  @OpenAPI({
+    summary: 'This value will be overwritten!',
+    description: 'This value will remain'
+  })
+  @OpenAPI({
+    summary: 'This value will remain'
+  })
+  listUsers() {
+    // ...
+  }
+```
+
 ## Supported features
 
 - `@Controller`/`@JsonController` base route and default content-type

--- a/__tests__/decorators.test.ts
+++ b/__tests__/decorators.test.ts
@@ -7,7 +7,7 @@ import {
 
 import { getOperation, getTags, IRoute, OpenAPI, parseRoutes } from '../src'
 
-describe('options', () => {
+describe('decorators', () => {
   let routes: IRoute[]
 
   beforeEach(() => {
@@ -32,6 +32,48 @@ describe('options', () => {
       getUser(@Param('userId') _userId: number) {
         return
       }
+
+      @Get('/multipleOpenAPIsWithObjectParam')
+      @OpenAPI({
+        summary: 'Some summary',
+        ['x-custom-key']: 'This will be overwritten'
+      })
+      @OpenAPI({
+        description: 'Some description',
+        ['x-custom-key']: 'Custom value'
+      })
+      multipleOpenAPIsWithObjectParam() {
+        return
+      }
+
+      @Get('/multipleOpenAPIsWithFunctionParam')
+      @OpenAPI((source, _route) => ({
+        ...source,
+        summary: 'Some summary',
+        'x-custom-key': 10
+      }))
+      @OpenAPI((source, _route) => ({
+        ...source,
+        description: 'Some description',
+        'x-custom-key': source['x-custom-key'] * 2
+      }))
+      multipleOpenAPIsWithFunctionParam() {
+        return
+      }
+
+      @Get('/multipleOpenAPIsWithMixedParam')
+      @OpenAPI({
+        summary: 'Some summary',
+        'x-custom-key': 10
+      })
+      @OpenAPI((source, _route) => ({
+        ...source,
+        description: 'Some description',
+        'x-custom-key': source['x-custom-key'] * 2
+      }))
+      multipleOpenAPIsWithMixedParam() {
+        return
+      }
     }
 
     routes = parseRoutes(getMetadataArgsStorage())
@@ -45,5 +87,26 @@ describe('options', () => {
   it('applies @OpenAPI decorator function parameter to operation', () => {
     const operation = getOperation(routes[1])
     expect(operation.tags).toEqual(['Users', 'custom-tag'])
+  })
+
+  it('merges consecutive @OpenAPI object parameters top-down', () => {
+    const operation = getOperation(routes[2])
+    expect(operation.summary).toEqual('Some summary')
+    expect(operation.description).toEqual('Some description')
+    expect(operation['x-custom-key']).toEqual('Custom value')
+  })
+
+  it('applies consecutive @OpenAPI function parameters top-down', () => {
+    const operation = getOperation(routes[3])
+    expect(operation.summary).toEqual('Some summary')
+    expect(operation.description).toEqual('Some description')
+    expect(operation['x-custom-key']).toEqual(20)
+  })
+
+  it('merges and applies consecutive @OpenAPI object and function parameters top-down', () => {
+    const operation = getOperation(routes[4])
+    expect(operation.summary).toEqual('Some summary')
+    expect(operation.description).toEqual('Some description')
+    expect(operation['x-custom-key']).toEqual(20)
   })
 })


### PR DESCRIPTION
Handle cases such as

```typescript
  @OpenAPI({
    summary: 'This value will be overwritten!',
    description: 'This value will remain'
  })
  @OpenAPI({
    summary: 'This value will remain'
  })
  listUsers() {
    // ...
  }
```

Previously the latter `OpenAPI` was ignored. With this PR, both decorators are applied top-down. 

This also enables using `OpenAPI` internally in custom decorators, as needed in #9.