### PR TITLE
Handle explicit type to define param schema

### DIFF
--- a/__tests__/fixtures/controllers.ts
+++ b/__tests__/fixtures/controllers.ts
@@ -98,6 +98,16 @@ export class UsersController {
     return
   }
 
+  @HttpCode(201)
+  @Post('/withType')
+  @ResponseSchema(ModelDto, {
+    description: 'Created user object',
+    statusCode: 201
+  })
+  createUserWithType(@QueryParam('user', { type: CreateUserBody }) _user: string) {
+    return
+  }
+
   @Put('/')
   createManyUsers(
     @Body({ required: true, type: CreateUserBody }) _body: CreateUserBody[]

--- a/__tests__/fixtures/spec.json
+++ b/__tests__/fixtures/spec.json
@@ -262,6 +262,35 @@
         "tags": ["Users"]
       }
     },
+    "/api/users/withType": {
+      "post": {
+        "operationId": "UsersController.createUserWithType",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/CreateUserBody"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelDto"
+                }
+              }
+            },
+            "description": "Created user object"
+          }
+        },
+        "summary": "Create user with type",
+        "tags": ["Users"]
+      }
+    },
     "/api/users/{from}-{to}": {
       "get": {
         "operationId": "UsersController.listUsersInRange",

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -82,6 +82,12 @@ describe('index', () => {
         type: 'post'
       },
       {
+        method: 'createUserWithType',
+        route: '/withType',
+        target: UsersController,
+        type: 'post'
+      },
+      {
         method: 'createManyUsers',
         route: '/',
         target: UsersController,

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -72,7 +72,7 @@ describe('options', () => {
     expect(getQueryParams(route)[1].required).toEqual(false)
   })
 
-  it('uses the explicit `type` parameter to override request body type', () => {
+  it('uses the explicit `type` parameter to override request query type', () => {
     const route = routes[1]
     expect(getQueryParams(route)[0]).toEqual({
       in: "query",
@@ -84,7 +84,7 @@ describe('options', () => {
     })
   })
 
-  it('uses the explicit `type` parameter to override array request body item type', () => {
+  it('uses the explicit `type` parameter to override request query array item type', () => {
     const route = routes[0]
     expect(getRequestBody(route)).toEqual({
       content: {

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -20,7 +20,8 @@ describe('options', () => {
   beforeEach(() => {
     getMetadataArgsStorage().reset()
 
-    class CreateUserBody {}
+    class CreateUserBody { }
+    class ParamType { }
 
     @JsonController('/users')
     // @ts-ignore: not referenced
@@ -35,7 +36,10 @@ describe('options', () => {
       }
 
       @Post('/:userId')
-      createManyUsers(@Body() _body: CreateUserBody[]) {
+      createManyUsers(
+        @QueryParam('param', { type: ParamType }) _param: string,
+        @Body() _body: CreateUserBody[],
+      ) {
         return
       }
     }
@@ -66,6 +70,18 @@ describe('options', () => {
     const route = routes[0]
     route.options.defaults = { paramOptions: { required: true } }
     expect(getQueryParams(route)[1].required).toEqual(false)
+  })
+
+  it('uses the explicit `type` parameter to override request body type', () => {
+    const route = routes[1]
+    expect(getQueryParams(route)[0]).toEqual({
+      in: "query",
+      name: "param",
+      required: false,
+      schema: {
+        $ref: '#/components/schemas/ParamType'
+      }
+    })
   })
 
   it('uses the explicit `type` parameter to override array request body item type', () => {

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -84,7 +84,7 @@ describe('options', () => {
     })
   })
 
-  it('uses the explicit `type` parameter to override request query array item type', () => {
+  it('uses the explicit `type` parameter to override array request body item type', () => {
     const route = routes[0]
     expect(getRequestBody(route)).toEqual({
       content: {

--- a/src/generateSpec.ts
+++ b/src/generateSpec.ts
@@ -173,18 +173,18 @@ export function getRequestBody(route: IRoute): oa.RequestBodyObject | void {
   const bodyParamsSchema: oa.SchemaObject | null =
     bodyParamMetas.length > 0
       ? bodyParamMetas.reduce(
-        (acc: oa.SchemaObject, d) => ({
-          ...acc,
-          properties: {
-            ...acc.properties,
-            [d.name!]: getParamSchema(d)
-          },
-          required: isRequired(d, route)
-            ? [...(acc.required || []), d.name!]
-            : acc.required
-        }),
-        { properties: {}, required: [], type: 'object' }
-      )
+          (acc: oa.SchemaObject, d) => ({
+            ...acc,
+            properties: {
+              ...acc.properties,
+              [d.name!]: getParamSchema(d)
+            },
+            required: isRequired(d, route)
+              ? [...(acc.required || []), d.name!]
+              : acc.required
+          }),
+          { properties: {}, required: [], type: 'object' }
+        )
       : null
 
   const bodyMeta = route.params.find(d => d.type === 'body')

--- a/src/generateSpec.ts
+++ b/src/generateSpec.ts
@@ -173,18 +173,18 @@ export function getRequestBody(route: IRoute): oa.RequestBodyObject | void {
   const bodyParamsSchema: oa.SchemaObject | null =
     bodyParamMetas.length > 0
       ? bodyParamMetas.reduce(
-          (acc: oa.SchemaObject, d) => ({
-            ...acc,
-            properties: {
-              ...acc.properties,
-              [d.name!]: getParamSchema(d)
-            },
-            required: isRequired(d, route)
-              ? [...(acc.required || []), d.name!]
-              : acc.required
-          }),
-          { properties: {}, required: [], type: 'object' }
-        )
+        (acc: oa.SchemaObject, d) => ({
+          ...acc,
+          properties: {
+            ...acc.properties,
+            [d.name!]: getParamSchema(d)
+          },
+          required: isRequired(d, route)
+            ? [...(acc.required || []), d.name!]
+            : acc.required
+        }),
+        { properties: {}, required: [], type: 'object' }
+      )
       : null
 
   const bodyMeta = route.params.find(d => d.type === 'body')
@@ -302,6 +302,15 @@ function getParamSchema(
   const { explicitType, index, object, method } = param
 
   const type = Reflect.getMetadata('design:paramtypes', object, method)[index]
+  if (_.isFunction(type) && type.name === 'Array') {
+    const items = explicitType
+      ? { $ref: '#/components/schemas/' + explicitType.name }
+      : { type: 'object' }
+    return { items, type: 'array' }
+  }
+  if (explicitType) {
+    return { $ref: '#/components/schemas/' + explicitType.name }
+  }
   if (_.isFunction(type)) {
     if (_.isString(type.prototype) || _.isSymbol(type.prototype)) {
       return { type: 'string' }
@@ -309,14 +318,10 @@ function getParamSchema(
       return { type: 'number' }
     } else if (_.isBoolean(type.prototype)) {
       return { type: 'boolean' }
-    } else if (type.name === 'Array') {
-      const items = explicitType
-        ? { $ref: '#/components/schemas/' + explicitType.name }
-        : { type: 'object' }
-      return { items, type: 'array' }
     } else if (type.name !== 'Object') {
       return { $ref: '#/components/schemas/' + type.name }
     }
   }
+
   return {}
 }


### PR DESCRIPTION
When Param is defined using options which include explicit type it should use this type to define parameter schema.