### PR TITLE
fix: unhandled exception for index not found in reflected types

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,50 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JSCodeStyleSettings version="0">
+      <option name="USE_SEMICOLON_AFTER_STATEMENT" value="false" />
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="Remove" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </JSCodeStyleSettings>
+    <TypeScriptCodeStyleSettings version="0">
+      <option name="USE_SEMICOLON_AFTER_STATEMENT" value="false" />
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_AFTER_DOTS_IN_REST_PARAMETER" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="Remove" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+      <option name="USE_CHAINED_CALLS_GROUP_INDENTS" value="true" />
+      <option name="IMPORT_SORT_MODULE_NAME" value="true" />
+    </TypeScriptCodeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="SPACE_BEFORE_COLON" value="false" />
+      <option name="IF_BRACE_FORCE" value="1" />
+      <option name="DOWHILE_BRACE_FORCE" value="1" />
+      <option name="WHILE_BRACE_FORCE" value="1" />
+      <option name="FOR_BRACE_FORCE" value="1" />
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+        <option name="SMART_TABS" value="true" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/routing-controllers-openapi.iml" filepath="$PROJECT_DIR$/.idea/routing-controllers-openapi.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/routing-controllers-openapi.iml
+++ b/.idea/routing-controllers-openapi.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/generateSpec.ts
+++ b/src/generateSpec.ts
@@ -32,9 +32,9 @@ export function getOperation(route: IRoute): oa.OperationObject {
   const operation: oa.OperationObject = {
     operationId: getOperationId(route),
     parameters: [
-      ...getHeaderParams(route),
-      ...getPathParams(route),
-      ...getQueryParams(route)
+      ... getHeaderParams(route),
+      ... getPathParams(route),
+      ... getQueryParams(route)
     ],
     requestBody: getRequestBody(route) || undefined,
     responses: getResponses(route),
@@ -64,7 +64,7 @@ export function getPaths(routes: IRoute[]): oa.PathObject {
   }))
 
   // @ts-ignore: array spread
-  return _.merge(...routePaths)
+  return _.merge(... routePaths)
 }
 
 /**
@@ -127,7 +127,7 @@ export function getPathParams(route: IRoute): oa.ParameterObject[] {
       if (meta) {
         const metaSchema = getParamSchema(meta)
         param.schema =
-          'type' in metaSchema ? { ...param.schema, ...metaSchema } : metaSchema
+          'type' in metaSchema ? { ... param.schema, ... metaSchema }: metaSchema
       }
 
       return param
@@ -173,18 +173,18 @@ export function getRequestBody(route: IRoute): oa.RequestBodyObject | void {
   const bodyParamsSchema: oa.SchemaObject | null =
     bodyParamMetas.length > 0
       ? bodyParamMetas.reduce(
-          (acc: oa.SchemaObject, d) => ({
-            ...acc,
-            properties: {
-              ...acc.properties,
-              [d.name!]: getParamSchema(d)
-            },
-            required: isRequired(d, route)
-              ? [...(acc.required || []), d.name!]
-              : acc.required
-          }),
-          { properties: {}, required: [], type: 'object' }
-        )
+      (acc: oa.SchemaObject, d) => ({
+        ... acc,
+        properties: {
+          ... acc.properties,
+          [d.name!]: getParamSchema(d)
+        },
+        required: isRequired(d, route)
+          ? [... (acc.required || []), d.name!]
+          : acc.required
+      }),
+      { properties: {}, required: [], type: 'object' }
+      )
       : null
 
   const bodyMeta = route.params.find(d => d.type === 'body')
@@ -192,7 +192,7 @@ export function getRequestBody(route: IRoute): oa.RequestBodyObject | void {
   if (bodyMeta) {
     const bodySchema = getParamSchema(bodyMeta)
     const { $ref } =
-      'items' in bodySchema && bodySchema.items ? bodySchema.items : bodySchema
+      'items' in bodySchema && bodySchema.items ? bodySchema.items: bodySchema
 
     return {
       content: {
@@ -221,7 +221,7 @@ export function getContentType(route: IRoute): string {
       ? 'application/json'
       : 'text/html; charset=utf-8'
   const contentMeta = _.find(route.responseHandlers, { type: 'content-type' })
-  return contentMeta ? contentMeta.value : defaultContentType
+  return contentMeta ? contentMeta.value: defaultContentType
 }
 
 /**
@@ -229,7 +229,7 @@ export function getContentType(route: IRoute): string {
  */
 export function getStatusCode(route: IRoute): string {
   const successMeta = _.find(route.responseHandlers, { type: 'success-code' })
-  return successMeta ? successMeta.value + '' : '200'
+  return successMeta ? successMeta.value + '': '200'
 }
 
 /**
@@ -279,7 +279,7 @@ export function getTags(route: IRoute): string[] {
 export function expressToOpenAPIPath(expressPath: string) {
   const tokens = pathToRegexp.parse(expressPath)
   return tokens
-    .map(d => (_.isString(d) ? d : `${d.prefix}{${d.name}}`))
+    .map(d => (_.isString(d) ? d: `${d.prefix}{${d.name}}`))
     .join('')
 }
 
@@ -289,7 +289,7 @@ export function expressToOpenAPIPath(expressPath: string) {
  */
 function isRequired(meta: { required?: boolean }, route: IRoute) {
   const globalRequired = _.get(route.options, 'defaults.paramOptions.required')
-  return globalRequired ? meta.required !== false : !!meta.required
+  return globalRequired ? meta.required !== false: !!meta.required
 }
 
 /**
@@ -300,8 +300,9 @@ function getParamSchema(
   param: ParamMetadataArgs
 ): oa.SchemaObject | oa.ReferenceObject {
   const { explicitType, index, object, method } = param
-
-  const type = Reflect.getMetadata('design:paramtypes', object, method)[index]
+  const reflectedTypes = Reflect.getMetadata('design:paramtypes', object, method);
+  if (reflectedTypes.length <= index) return {};
+  const type = reflectedTypes[index]
   if (_.isFunction(type) && type.name === 'Array') {
     const items = explicitType
       ? { $ref: '#/components/schemas/' + explicitType.name }

--- a/src/generateSpec.ts
+++ b/src/generateSpec.ts
@@ -32,9 +32,9 @@ export function getOperation(route: IRoute): oa.OperationObject {
   const operation: oa.OperationObject = {
     operationId: getOperationId(route),
     parameters: [
-      ... getHeaderParams(route),
-      ... getPathParams(route),
-      ... getQueryParams(route)
+      ...getHeaderParams(route),
+      ...getPathParams(route),
+      ...getQueryParams(route)
     ],
     requestBody: getRequestBody(route) || undefined,
     responses: getResponses(route),
@@ -64,7 +64,7 @@ export function getPaths(routes: IRoute[]): oa.PathObject {
   }))
 
   // @ts-ignore: array spread
-  return _.merge(... routePaths)
+  return _.merge(...routePaths)
 }
 
 /**
@@ -127,7 +127,7 @@ export function getPathParams(route: IRoute): oa.ParameterObject[] {
       if (meta) {
         const metaSchema = getParamSchema(meta)
         param.schema =
-          'type' in metaSchema ? { ... param.schema, ... metaSchema }: metaSchema
+          'type' in metaSchema ? { ...param.schema, ...metaSchema } : metaSchema
       }
 
       return param
@@ -173,18 +173,18 @@ export function getRequestBody(route: IRoute): oa.RequestBodyObject | void {
   const bodyParamsSchema: oa.SchemaObject | null =
     bodyParamMetas.length > 0
       ? bodyParamMetas.reduce(
-      (acc: oa.SchemaObject, d) => ({
-        ... acc,
-        properties: {
-          ... acc.properties,
-          [d.name!]: getParamSchema(d)
-        },
-        required: isRequired(d, route)
-          ? [... (acc.required || []), d.name!]
-          : acc.required
-      }),
-      { properties: {}, required: [], type: 'object' }
-      )
+          (acc: oa.SchemaObject, d) => ({
+            ...acc,
+            properties: {
+              ...acc.properties,
+              [d.name!]: getParamSchema(d)
+            },
+            required: isRequired(d, route)
+              ? [...(acc.required || []), d.name!]
+              : acc.required
+          }),
+          { properties: {}, required: [], type: 'object' }
+        )
       : null
 
   const bodyMeta = route.params.find(d => d.type === 'body')
@@ -192,7 +192,7 @@ export function getRequestBody(route: IRoute): oa.RequestBodyObject | void {
   if (bodyMeta) {
     const bodySchema = getParamSchema(bodyMeta)
     const { $ref } =
-      'items' in bodySchema && bodySchema.items ? bodySchema.items: bodySchema
+      'items' in bodySchema && bodySchema.items ? bodySchema.items : bodySchema
 
     return {
       content: {
@@ -221,7 +221,7 @@ export function getContentType(route: IRoute): string {
       ? 'application/json'
       : 'text/html; charset=utf-8'
   const contentMeta = _.find(route.responseHandlers, { type: 'content-type' })
-  return contentMeta ? contentMeta.value: defaultContentType
+  return contentMeta ? contentMeta.value : defaultContentType
 }
 
 /**
@@ -229,7 +229,7 @@ export function getContentType(route: IRoute): string {
  */
 export function getStatusCode(route: IRoute): string {
   const successMeta = _.find(route.responseHandlers, { type: 'success-code' })
-  return successMeta ? successMeta.value + '': '200'
+  return successMeta ? successMeta.value + '' : '200'
 }
 
 /**
@@ -279,7 +279,7 @@ export function getTags(route: IRoute): string[] {
 export function expressToOpenAPIPath(expressPath: string) {
   const tokens = pathToRegexp.parse(expressPath)
   return tokens
-    .map(d => (_.isString(d) ? d: `${d.prefix}{${d.name}}`))
+    .map(d => (_.isString(d) ? d : `${d.prefix}{${d.name}}`))
     .join('')
 }
 
@@ -289,7 +289,7 @@ export function expressToOpenAPIPath(expressPath: string) {
  */
 function isRequired(meta: { required?: boolean }, route: IRoute) {
   const globalRequired = _.get(route.options, 'defaults.paramOptions.required')
-  return globalRequired ? meta.required !== false: !!meta.required
+  return globalRequired ? meta.required !== false : !!meta.required
 }
 
 /**
@@ -300,8 +300,12 @@ function getParamSchema(
   param: ParamMetadataArgs
 ): oa.SchemaObject | oa.ReferenceObject {
   const { explicitType, index, object, method } = param
-  const reflectedTypes = Reflect.getMetadata('design:paramtypes', object, method);
-  if (reflectedTypes.length <= index) return {};
+  const reflectedTypes = Reflect.getMetadata(
+    'design:paramtypes',
+    object,
+    method
+  )
+  if (reflectedTypes.length <= index) return {}
   const type = reflectedTypes[index]
   if (_.isFunction(type) && type.name === 'Array') {
     const items = explicitType

--- a/yarn.lock
+++ b/yarn.lock
@@ -840,6 +840,11 @@ convert-source-map@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
+cookie@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
@@ -1267,6 +1272,18 @@ glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
 glob@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.4:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2845,6 +2862,16 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
+routing-controllers@^0.8.0:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/routing-controllers/-/routing-controllers-0.8.1.tgz#d53c35e05d0f0863ee25bd77c3fe41fc09fa39f5"
+  integrity sha512-dOgt0kiriKMH1swenPX73tU3Mxvlb+1N/sFLSgEpwbK314POrQF+dJGOZVoKv2ya5do1k4aUzSV5xi0K3ykdyw==
+  dependencies:
+    cookie "^0.4.0"
+    glob "^7.1.4"
+    reflect-metadata "^0.1.13"
+    template-url "^1.0.0"
+
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -3180,6 +3207,11 @@ teeny-request@6.0.1:
     node-fetch "^2.2.0"
     stream-events "^1.0.5"
     uuid "^3.3.2"
+
+template-url@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/template-url/-/template-url-1.0.0.tgz#d9456bee70cac6617b462a7b08db29fb813a0b09"
+  integrity sha1-2UVr7nDKxmF7Rip7CNsp+4E6Cwk=
 
 test-exclude@^5.2.3:
   version "5.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -840,11 +840,6 @@ convert-source-map@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
-cookie@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
-  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
-
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
@@ -1272,18 +1267,6 @@ glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
 glob@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.4:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -2862,16 +2845,6 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
-routing-controllers@^0.8.0:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/routing-controllers/-/routing-controllers-0.8.1.tgz#d53c35e05d0f0863ee25bd77c3fe41fc09fa39f5"
-  integrity sha512-dOgt0kiriKMH1swenPX73tU3Mxvlb+1N/sFLSgEpwbK314POrQF+dJGOZVoKv2ya5do1k4aUzSV5xi0K3ykdyw==
-  dependencies:
-    cookie "^0.4.0"
-    glob "^7.1.4"
-    reflect-metadata "^0.1.13"
-    template-url "^1.0.0"
-
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -3207,11 +3180,6 @@ teeny-request@6.0.1:
     node-fetch "^2.2.0"
     stream-events "^1.0.5"
     uuid "^3.3.2"
-
-template-url@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/template-url/-/template-url-1.0.0.tgz#d9456bee70cac6617b462a7b08db29fb813a0b09"
-  integrity sha1-2UVr7nDKxmF7Rip7CNsp+4E6Cwk=
 
 test-exclude@^5.2.3:
   version "5.2.3"


### PR DESCRIPTION
Fix for:
On 

   const { explicitType, index, object, method } = param;
        const type = Reflect.getMetadata('design:paramtypes', object, method)[index];

An error can be thrown if the index is not in the array;
