### PR TITLE
fix: typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Note that when using `@ResponseSchema` together with `@JSONSchema`, the outer de
           '$ref': '#/components/schemas/Pet'
         }
       }
-    ]
+    }
   }
 }})
 @ResponseSchema(SomeResponseObject)


### PR DESCRIPTION
Fix typo in `@JSONSchema` example.