### PR TITLE
Add support for multiple @QueryParams

### DIFF
--- a/__tests__/parameters.test.ts
+++ b/__tests__/parameters.test.ts
@@ -39,6 +39,15 @@ describe('parameters', () => {
       @IsString({ each: true })
       types: string[]
     }
+    class AdditionalQueryParams {
+      @IsBoolean()
+      @IsOptional()
+      includeRelationships: boolean
+
+      @IsBoolean()
+      @IsOptional()
+      includePets: boolean
+    }
 
     @JsonController('/users')
     // @ts-ignore: not referenced
@@ -53,6 +62,7 @@ describe('parameters', () => {
         @HeaderParam('Authorization', { required: true })
         _authorization: string,
         @QueryParams() _queryRef?: ListUsersQueryParams,
+        @QueryParams() _queryRef2?: AdditionalQueryParams,
         @HeaderParams() _headerParams?: ListUsersHeaderParams
       ) {
         return
@@ -161,7 +171,7 @@ describe('parameters', () => {
     })
   })
 
-  it('parses query param ref from @QueryParams decorator', () => {
+  it('parses query param refs from @QueryParams decorator', () => {
     expect(getQueryParams(route, schemas)).toEqual([
       // limit comes from @QueryParam
       {
@@ -193,6 +203,22 @@ describe('parameters', () => {
             type: 'string',
           },
           type: 'array',
+        },
+      },
+      {
+        in: 'query',
+        name: 'includeRelationships',
+        required: false,
+        schema: {
+          type: 'boolean',
+        },
+      },
+      {
+        in: 'query',
+        name: 'includePets',
+        required: false,
+        schema: {
+          type: 'boolean',
         },
       },
     ])

--- a/src/generateSpec.ts
+++ b/src/generateSpec.ts
@@ -170,24 +170,25 @@ export function getQueryParams(
       }
     })
 
-  const queriesMeta = route.params.find((p) => p.type === 'queries')
-  if (queriesMeta) {
-    const paramSchema = getParamSchema(queriesMeta) as oa.ReferenceObject
-    // the last segment after '/'
-    const paramSchemaName = paramSchema.$ref.split('/').pop() || ''
-    const currentSchema = schemas[paramSchemaName]
+  route.params
+    .filter((p) => p.type === 'queries')
+    .forEach((queriesMeta) => {
+      const paramSchema = getParamSchema(queriesMeta) as oa.ReferenceObject
+      // the last segment after '/'
+      const paramSchemaName = paramSchema.$ref.split('/').pop() || ''
+      const currentSchema = schemas[paramSchemaName]
 
-    for (const [name, schema] of Object.entries(
-      currentSchema?.properties || {}
-    )) {
-      queries.push({
-        in: 'query',
-        name,
-        required: currentSchema.required?.includes(name),
-        schema,
-      })
-    }
-  }
+      for (const [name, schema] of Object.entries(
+        currentSchema?.properties || {}
+      )) {
+        queries.push({
+          in: 'query',
+          name,
+          required: currentSchema.required?.includes(name) || false,
+          schema,
+        })
+      }
+    })
   return queries
 }
 


### PR DESCRIPTION
I felt it would be useful to be able to split the `QueryParams` into multiple validated classes.