### PR TITLE
added wildcard instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ will generate
 - `@Get`, `@Post` and other action decorators
 - Parse path parameters straight from path strings and optionally supplement with `@Param` decorator
   - Regex and optional path parameters (e.g. `/users/:id(\d+)/:type?`) are also supported
+  - Note that express >=40's no wildcard asterisk (`*`) - use parameters instead (`(.*)` or `:splat*`)
 - `@QueryParam` and `@QueryParams`
 - `@HeaderParam` and `@HeaderParams`
 - `@Body` and `@BodyParam`


### PR DESCRIPTION
I was confused about wildcards (*) crashing the app.
I wanted to add the functionality but as I was researching I found out it actually was in `path-to-regexp`.

Researching that I found out you can make it work [this way](https://github.com/pillarjs/path-to-regexp#compatibility-with-express--4x), so I added it to the README for users to find.

