### PR TITLE
Support integer type in getParamSchema

### DIFF
--- a/src/generateSpec.ts
+++ b/src/generateSpec.ts
@@ -346,6 +346,9 @@ function getParamSchema(
     return { items, type: 'array' }
   }
   if (explicitType) {
+    if (explicitType.name === 'integer') {
+      return { type: 'integer' }
+    }
     return { $ref: '#/components/schemas/' + explicitType.name }
   }
   if (typeof type === 'function') {


### PR DESCRIPTION
I haven't found a way to create integer params except for explicitly specifying all the params in OpenAPI decorator:
```
@OpenAPI({parameters: [{in: 'query', name: 'userId', required: true, schema: { type: 'integer' }}]})
```

With this change this will be possible to do via *Param decorators:
```
@QueryParam('userId', { required: true, type: { name: 'integer' } }) userId
```