### PR TITLE
lazily generate schemas for classes that are missing schemas

### DIFF
--- a/__tests__/fixtures/controllers.ts
+++ b/__tests__/fixtures/controllers.ts
@@ -34,10 +34,12 @@ export class CreateNestedBody {
   users: CreateUserBody[]
 }
 
-export class CreatePostBody {
+class CreatePostBodyBase {
   @IsString({ each: true })
   content: string[]
 }
+
+export class CreatePostBody extends CreatePostBodyBase {}
 
 export class ListUsersQueryParams {
   @IsOptional()
@@ -130,7 +132,7 @@ export class UsersController {
 
   @Post('/:userId/posts')
   createUserPost(
-    @Body({ required: true }) _body: CreatePostBody,
+    @Body({ required: true, type: CreatePostBody }) _body: CreatePostBody,
     @BodyParam('token') _token: string
   ) {
     return

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
         "@types/rimraf": "^3.0.0",
         "@types/validator": "^13.7.10",
         "class-transformer": "^0.5.1",
-        "class-validator": "^0.13.2",
-        "class-validator-jsonschema": "^3.1.1",
+        "class-validator": "^0.14.1",
+        "class-validator-jsonschema": "^5.0.1",
         "codecov": "^3.8.1",
         "jest": "^29.3.1",
         "prettier": "^2.8.0",
@@ -1254,10 +1254,9 @@
       "dev": true
     },
     "node_modules/@types/validator": {
-      "version": "13.7.10",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.10.tgz",
-      "integrity": "sha512-t1yxFAR2n0+VO6hd/FJ9F2uezAZVWHLmpmlJzm1eX03+H7+HsuTAp7L8QJs+2pQCfWkP1+EXsGK9Z9v7o/qPVQ==",
-      "dev": true
+      "version": "13.11.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.10.tgz",
+      "integrity": "sha512-e2PNXoXLr6Z+dbfx5zSh9TRlXJrELycxiaXznp4S5+D2M3b9bqJEitNHA5923jhnB2zzFiZHa2f0SI1HoIahpg=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.17",
@@ -1740,29 +1739,51 @@
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "node_modules/class-validator": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.2.tgz",
-      "integrity": "sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
+      "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
       "dependencies": {
-        "libphonenumber-js": "^1.9.43",
-        "validator": "^13.7.0"
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.10.53",
+        "validator": "^13.9.0"
       }
     },
     "node_modules/class-validator-jsonschema": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/class-validator-jsonschema/-/class-validator-jsonschema-3.1.1.tgz",
-      "integrity": "sha512-xga/5rTDKaYysivdX6OWaVllAS2OGeXgRRaXRo5QAW+mSDOpbjrf5JhmdPvUKMEkGyQer0gCoferB3COl170Rg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/class-validator-jsonschema/-/class-validator-jsonschema-5.0.1.tgz",
+      "integrity": "sha512-9uTdo5jSnJUj7f0dS8YZDqM0Fv1Uky0BWefswnNa2F4nRcKPCiEb5z3nDUaXyEzcERCrizE+0AGDSao1uSNX9g==",
       "dev": true,
       "dependencies": {
         "lodash.groupby": "^4.6.0",
         "lodash.merge": "^4.6.2",
-        "openapi3-ts": "^2.0.0",
+        "openapi3-ts": "^3.0.0",
         "reflect-metadata": "^0.1.13",
-        "tslib": "^2.0.3"
+        "tslib": "^2.4.1"
       },
       "peerDependencies": {
         "class-transformer": "^0.4.0 || ^0.5.0",
-        "class-validator": "^0.13.1"
+        "class-validator": "^0.14.0"
+      }
+    },
+    "node_modules/class-validator-jsonschema/node_modules/openapi3-ts": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.2.0.tgz",
+      "integrity": "sha512-/ykNWRV5Qs0Nwq7Pc0nJ78fgILvOT/60OxEmB3v7yQ8a8Bwcm43D4diaYazG/KBn6czA+52XYy931WFLMCUeSg==",
+      "dev": true,
+      "dependencies": {
+        "yaml": "^2.2.1"
+      }
+    },
+    "node_modules/class-validator-jsonschema/node_modules/yaml": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.3.tgz",
+      "integrity": "sha512-sntgmxj8o7DE7g/Qi60cqpLBA3HG3STcDA0kO+WfB05jEKhZMbY7umNm2rBpQvsmZ16/lPXCJGW2672dgOUkrg==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/cliui": {
@@ -3855,9 +3876,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.10.15",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.15.tgz",
-      "integrity": "sha512-sLeVLmWX17VCKKulc+aDIRHS95TxoTsKMRJi5s5gJdwlqNzMWcBCtSHHruVyXjqfi67daXM2SnLf2juSrdx5Sg=="
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.3.tgz",
+      "integrity": "sha512-RU0CTsLCu2v6VEzdP+W6UU2n5+jEpMDRkGxUeBgsAJgre3vKgm17eApISH9OQY4G0jZYJVIc8qXmz6CJFueAFg=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -5651,9 +5672,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -6781,10 +6802,9 @@
       "dev": true
     },
     "@types/validator": {
-      "version": "13.7.10",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.10.tgz",
-      "integrity": "sha512-t1yxFAR2n0+VO6hd/FJ9F2uezAZVWHLmpmlJzm1eX03+H7+HsuTAp7L8QJs+2pQCfWkP1+EXsGK9Z9v7o/qPVQ==",
-      "dev": true
+      "version": "13.11.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.10.tgz",
+      "integrity": "sha512-e2PNXoXLr6Z+dbfx5zSh9TRlXJrELycxiaXznp4S5+D2M3b9bqJEitNHA5923jhnB2zzFiZHa2f0SI1HoIahpg=="
     },
     "@types/yargs": {
       "version": "17.0.17",
@@ -7152,25 +7172,43 @@
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "class-validator": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.2.tgz",
-      "integrity": "sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
+      "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
       "requires": {
-        "libphonenumber-js": "^1.9.43",
-        "validator": "^13.7.0"
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.10.53",
+        "validator": "^13.9.0"
       }
     },
     "class-validator-jsonschema": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/class-validator-jsonschema/-/class-validator-jsonschema-3.1.1.tgz",
-      "integrity": "sha512-xga/5rTDKaYysivdX6OWaVllAS2OGeXgRRaXRo5QAW+mSDOpbjrf5JhmdPvUKMEkGyQer0gCoferB3COl170Rg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/class-validator-jsonschema/-/class-validator-jsonschema-5.0.1.tgz",
+      "integrity": "sha512-9uTdo5jSnJUj7f0dS8YZDqM0Fv1Uky0BWefswnNa2F4nRcKPCiEb5z3nDUaXyEzcERCrizE+0AGDSao1uSNX9g==",
       "dev": true,
       "requires": {
         "lodash.groupby": "^4.6.0",
         "lodash.merge": "^4.6.2",
-        "openapi3-ts": "^2.0.0",
+        "openapi3-ts": "^3.0.0",
         "reflect-metadata": "^0.1.13",
-        "tslib": "^2.0.3"
+        "tslib": "^2.4.1"
+      },
+      "dependencies": {
+        "openapi3-ts": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.2.0.tgz",
+          "integrity": "sha512-/ykNWRV5Qs0Nwq7Pc0nJ78fgILvOT/60OxEmB3v7yQ8a8Bwcm43D4diaYazG/KBn6czA+52XYy931WFLMCUeSg==",
+          "dev": true,
+          "requires": {
+            "yaml": "^2.2.1"
+          }
+        },
+        "yaml": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.3.tgz",
+          "integrity": "sha512-sntgmxj8o7DE7g/Qi60cqpLBA3HG3STcDA0kO+WfB05jEKhZMbY7umNm2rBpQvsmZ16/lPXCJGW2672dgOUkrg==",
+          "dev": true
+        }
       }
     },
     "cliui": {
@@ -8788,9 +8826,9 @@
       "dev": true
     },
     "libphonenumber-js": {
-      "version": "1.10.15",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.15.tgz",
-      "integrity": "sha512-sLeVLmWX17VCKKulc+aDIRHS95TxoTsKMRJi5s5gJdwlqNzMWcBCtSHHruVyXjqfi67daXM2SnLf2juSrdx5Sg=="
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.3.tgz",
+      "integrity": "sha512-RU0CTsLCu2v6VEzdP+W6UU2n5+jEpMDRkGxUeBgsAJgre3vKgm17eApISH9OQY4G0jZYJVIc8qXmz6CJFueAFg=="
     },
     "lines-and-columns": {
       "version": "1.2.4",
@@ -10165,9 +10203,9 @@
       }
     },
     "validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "singleQuote": true
   },
   "dependencies": {
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "class-validator-jsonschema": "^5.0.1",
     "lodash.capitalize": "^4.2.1",
     "lodash.merge": "^4.6.2",
     "lodash.startcase": "^4.4.0",
@@ -47,9 +50,6 @@
     "@types/reflect-metadata": "^0.1.0",
     "@types/rimraf": "^3.0.0",
     "@types/validator": "^13.7.10",
-    "class-transformer": "^0.5.1",
-    "class-validator": "^0.13.2",
-    "class-validator-jsonschema": "^3.1.1",
     "codecov": "^3.8.1",
     "jest": "^29.3.1",
     "prettier": "^2.8.0",


### PR DESCRIPTION
If a class does not have a decorator on it, there will be no OpenAPI schema generated for it, even though it may be used in certain endpoints, e.g. `export class CreatePostBody extends CreatePostBodyBase {}`.

This fix generates a schema for the classes that are missing schemas.