### PR TITLE
feat: Add support for @Params() decorator

### DIFF
--- a/__tests__/parameters.test.ts
+++ b/__tests__/parameters.test.ts
@@ -233,6 +233,16 @@ describe('parameters', () => {
           pattern: '^[0-9a-fA-F]{24}$',
         },
       },
+      {
+        in: 'path',
+        name: 'name',
+        required: false,
+        schema: {
+          description: 'Name of the user',
+          example: 'John Doe',
+          type: 'string',
+        },
+      },
     ])
   })
 

--- a/__tests__/parameters.test.ts
+++ b/__tests__/parameters.test.ts
@@ -74,7 +74,9 @@ describe('parameters', () => {
     @JsonController('/users')
     // @ts-ignore: not referenced
     class UsersController {
-      @Get('/:string/:regex(\\d{6})/:optional?/:number/:boolean/:any')
+      @Get(
+        '/:string/:regex(\\d{6})/:optional?/:number/:boolean/:any/:id/:name?'
+      )
       getPost(
         @Param('number') _numberParam: number,
         @Param('invalid') _invalidParam: string,
@@ -134,6 +136,18 @@ describe('parameters', () => {
         in: 'path',
         name: 'any',
         required: true,
+        schema: { pattern: '[^\\/#\\?]+?', type: 'string' },
+      },
+      {
+        in: 'path',
+        name: 'id',
+        required: true,
+        schema: { pattern: '[^\\/#\\?]+?', type: 'string' },
+      },
+      {
+        in: 'path',
+        name: 'name',
+        required: false,
         schema: { pattern: '[^\\/#\\?]+?', type: 'string' },
       },
     ])

--- a/src/generateSpec.ts
+++ b/src/generateSpec.ts
@@ -164,12 +164,19 @@ export function getPathParams(
       for (const [name, schema] of Object.entries(
         currentSchema?.properties || {}
       )) {
-        params.push({
-          in: 'path',
-          name,
-          required: currentSchema.required?.includes(name),
-          schema,
-        })
+        // Check if the parameter name is already in the params array.
+        const existingParam = params.find((param) => param.name === name)
+        if (existingParam) {
+          // remove and replace with more specific schema
+          params.splice(params.indexOf(existingParam), 1)
+          params.push({
+            in: 'path',
+            name,
+            required: currentSchema.required?.includes(name),
+            schema,
+          })
+          continue
+        }
       }
     }
   }


### PR DESCRIPTION
In version 5.0.0, the OpenAPI generator did not parse or generate the JSONSchema defined on fields in `class-validator` classes used with the `@Params()` decorator. This caused issues when attempting to generate accurate OpenAPI specifications, as the schema for path parameters would be missing in the final output.

Basic tests have been added to verify the feature works as expected.

Example -

```javascript
class ListUserParams {
  @IsMongoId()
  @IsString()
  @JSONSchema({
    description: 'ID of the user',
    example: '60d5ec49b3f1c8e4a8f8b8c1',
    type: 'string',
    format: 'Mongo ObjectId',
  })
  id: string;

  @IsString()
  @IsOptional()
  @JSONSchema({
    description: 'Name of the user',
    example: 'John Doe',
    type: 'string',
  })
  name: string;
}

```

Generated Spec
```javascript
      {
        in: 'path',
        name: 'id',
        required: true,
        schema: {
          description: 'ID of the user',
          example: '60d5ec49b3f1c8e4a8f8b8c1',
          type: 'string',
          format: 'Mongo ObjectId',
          pattern: '^[0-9a-fA-F]{24}$',
        },
      },
      {
        in: 'path',
        name: 'name',
        required: false,
        schema: {
          description: 'Name of the user',
          example: 'John Doe',
          type: 'string',
        },
      },
```


